### PR TITLE
Expose port 80 in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,7 @@ RUN npm install
 
 COPY src /usr/src
 
+ENV PORT=80
+EXPOSE 80
+
 CMD ["node", "index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,11 +9,8 @@ services:
       - TOTP_SECRET=GRWGIJS6IRHVEODVNRCXCOBMJ5AGC6ZE
       - JWT_SECRET=unsecure_secret
       - JWT_EXPIRATION_TIME=1h
-      - PORT=80
     depends_on:
       - ldap
-    expose:
-      - "80"
     restart: always
 
   ldap:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "two-factor-auth-server",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Simple two factor authentication server with LDAP backend and TOTP",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Exposes port 80 in the Dockerfile so that in can be used as a docker service by docker swarm